### PR TITLE
Allow for multiple merges

### DIFF
--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -2,7 +2,7 @@
 import { parse } from 'graphql';
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import print from './utilities/astPrinter';
-import { isObjectTypeDefinition } from './utilities/astHelpers';
+import { isObjectTypeDefinition, isObjectSchemaDefinition } from './utilities/astHelpers';
 import { makeSchema, mergeableTypes } from './utilities/makeSchema';
 
 const _isMergeableTypeDefinition = def =>
@@ -33,7 +33,7 @@ const _addCommentsToAST = (nodes, flatten = true) => {
 
 const _makeRestDefinitions = defs =>
   defs
-    .filter(_isNonMergeableTypeDefinition)
+    .filter(def => _isNonMergeableTypeDefinition(def) && !isObjectSchemaDefinition(def))
     .map((def) => {
       if (isObjectTypeDefinition(def)) {
         return {
@@ -100,7 +100,8 @@ const mergeTypes = (types) => {
 
   const mergedDefs = _makeMergedDefinitions(allDefs);
   const rest = _addCommentsToAST(_makeRestDefinitions(allDefs), false).map(printDefinitions);
-  const schema = printDefinitions([makeSchema(mergedDefs), ...mergedDefs]);
+  const schemaDefs = allDefs.filter(isObjectSchemaDefinition);
+  const schema = printDefinitions([makeSchema(mergedDefs, schemaDefs), ...mergedDefs]);
 
   return [schema, ...rest].join('\n');
 };

--- a/src/utilities/astHelpers.js
+++ b/src/utilities/astHelpers.js
@@ -5,4 +5,6 @@ const hasDefinitionWithName = (nodes, name) =>
 
 const isObjectTypeDefinition = def => def.kind === Kind.OBJECT_TYPE_DEFINITION;
 
-export { hasDefinitionWithName, isObjectTypeDefinition };
+const isObjectSchemaDefinition = def => def.kind === Kind.SCHEMA_DEFINITION;
+
+export { hasDefinitionWithName, isObjectTypeDefinition, isObjectSchemaDefinition };

--- a/src/utilities/makeSchema.js
+++ b/src/utilities/makeSchema.js
@@ -1,11 +1,13 @@
 import { Kind } from 'graphql';
 import { hasDefinitionWithName } from './astHelpers';
 
-const _mergeableOperationTypes = [
-  'query',
-  'mutation',
-  'subscription',
-];
+const typesMap = {
+  query: 'Query',
+  mutation: 'Mutation',
+  subscription: 'Subscription',
+};
+
+const _mergeableOperationTypes = Object.keys(typesMap);
 
 const _makeOperationType = (operation, value) => (
   {
@@ -21,27 +23,42 @@ const _makeOperationType = (operation, value) => (
   }
 );
 
-const mergeableTypes = [
-  'Query',
-  'Mutation',
-  'Subscription',
-];
+const mergeableTypes = Object.values(typesMap);
 
-const makeSchema = (definitions) => {
-  const operationTypes = mergeableTypes
+const makeSchema = (definitions, schemaDefs) => {
+  const operationMap = {
+    query: _makeOperationType(_mergeableOperationTypes[0], mergeableTypes[0]),
+    mutation: null,
+    subscription: null,
+  };
+
+  mergeableTypes
     .slice(1)
-    .map(
+    .forEach(
       (type, key) => {
         if (hasDefinitionWithName(definitions, type)) {
-          return _makeOperationType(_mergeableOperationTypes[key + 1], type);
+          const operation = _mergeableOperationTypes[key + 1];
+
+          operationMap[operation] = _makeOperationType(operation, type);
         }
-
-        return null;
       },
-    )
-    .filter(operationType => operationType);
+    );
 
-  operationTypes.unshift(_makeOperationType(_mergeableOperationTypes[0], mergeableTypes[0]));
+  const operationTypes = Object.values(operationMap)
+    .map((operation, i) => {
+      if (!operation) {
+        const type = Object.keys(operationMap)[i];
+
+        if (schemaDefs.some(def =>
+          def.operationTypes.some(op => op.operation === type),
+        )) {
+          return _makeOperationType(type, typesMap[type]);
+        }
+      }
+
+      return operation;
+    })
+    .filter(op => op);
 
   return {
     kind: Kind.SCHEMA_DEFINITION,

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -194,6 +194,25 @@ describe('mergeTypes', () => {
     expect(schema).toContain(expectedSchemaType);
   });
 
+  it('includes one schemaType on multiple merges', () => {
+    const matchSchema = /\s*schema\s+\{[^\}]+\}/gm;
+    const types = mergeTypes([clientType, productType]);
+    const multipleMergedTypes = mergeTypes([types, vendorType]);
+    const expectedSchemaType = normalizeWhitespace(`
+      schema {
+        query: Query
+        mutation: Mutation
+        subscription: Subscription
+      }
+    `);
+    const schema = normalizeWhitespace(multipleMergedTypes);
+
+    const matches = schema.match(matchSchema);
+
+    expect(schema).toContain(expectedSchemaType);
+    expect(matches.length).toEqual(1);
+  });
+
   it('includes queryType', () => {
     const types = [clientType, productType];
     const mergedTypes = mergeTypes(types);


### PR DESCRIPTION
`mergeTypes()`:

1. I excluded `SCHEMA_DEFINITION` from the `rest` definitions
1. passed them to `makeSchema()` as the second argument

`makeSchema()`:

1. it still loops through definitions to find if there's a `Query`, `Mutation` or `Subscription`
1. since we've got an array with `SCHEMA_DEFINITION` objects
1. if some of the operations is missing, it checks the provided array with schema definitions.
1. then adds it to operations

This way we always have every operation that is needed.



Closes #63