### PR TITLE
Adds File Loader Option to Recursively Load Files

### DIFF
--- a/src/file_loader.js
+++ b/src/file_loader.js
@@ -1,25 +1,46 @@
 import fs from 'fs';
 import path from 'path';
 
-const fileLoader = (folderPath) => {
+const recursiveReadDirSync = dir =>
+  fs.readdirSync(dir)
+    .reduce((files, file) => (
+      fs.statSync(path.join(dir, file)).isDirectory() ?
+        files.concat(recursiveReadDirSync(path.join(dir, file))) :
+        files.concat(path.join(dir, file))
+      ),
+      []);
+
+const readDirSync = dir =>
+  fs.readdirSync(dir)
+    .reduce((files, file) => (
+      fs.statSync(path.join(dir, file)).isDirectory() ?
+        files :
+        files.concat(path.join(dir, file))
+      ),
+      []);
+
+const fileLoader = (folderPath, options = { recursive: false }) => {
   const dir = folderPath;
   const files = [];
-  fs.readdirSync(dir).forEach((f) => {
+  const schemafiles = options.recursive === true ?
+                  recursiveReadDirSync(dir) :
+                  readDirSync(dir);
+
+  schemafiles.forEach((f) => {
     const pathObj = path.parse(f);
-    const filesDir = path.join(dir, f);
 
     if (pathObj.name.toLowerCase() === 'index') { return; }
 
     switch (pathObj.ext) {
       case '.js': {
-        const file = require(filesDir); // eslint-disable-line
+        const file = require(f); // eslint-disable-line
         files.push(file.default || file);
         break;
       }
 
       case '.graphqls':
       case '.graphql': {
-        const file = fs.readFileSync(filesDir, 'utf8');
+        const file = fs.readFileSync(f, 'utf8');
         files.push(file.toString());
         break;
       }

--- a/test/file_loader.test.js
+++ b/test/file_loader.test.js
@@ -29,4 +29,16 @@ describe('fileLoader', () => {
 
     expect(loadedResolvers).toEqual(resolvers);
   });
+
+  it('loads all files recursively from specified folder', () => {
+    const rawType = fs.readFileSync(`${__dirname}/graphql/types/raw_type.graphqls`).toString();
+
+    const types = [
+      productType, clientType, personEntityType, personSearchType, rawType, vendorType,
+    ];
+
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/nested_types'), {recursive: true});
+
+    expect(loadedTypes).toEqual(types);
+  })
 });

--- a/test/graphql/nested_types/client/product_type.js
+++ b/test/graphql/nested_types/client/product_type.js
@@ -1,0 +1,37 @@
+export default `
+  type Product {
+    id: ID!
+    description: String
+    price: Int
+    tag: TAG
+    clients: [Client]
+  }
+
+  type Query {
+    products: [Product]
+    product(id: ID!): Product
+  }
+
+  type Mutation {
+    create_product(description: String!, price: Int!): Product
+    update_product(id: ID!, description: String!, price: Int!): Product
+  }
+
+  type Subscription {
+    activeProducts: [Product]
+  }
+
+  enum ProductTypes {
+    NEW
+    USED
+    REFURBISHED
+  }
+
+  scalar TAG
+
+  enum ProductPriceType {
+    REGULAR
+    PROMOTION
+    SALE
+  }
+`;

--- a/test/graphql/nested_types/client_type.js
+++ b/test/graphql/nested_types/client_type.js
@@ -1,0 +1,65 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+    age: Int
+    dob: Date
+    settings: JSON
+    products: [Product]
+  }
+
+  # Comments on top of type definition
+  # Second comment line
+  # Third comment line
+  # Fourth comment line
+  type ClientWithCommentOnTop {
+    # ClientID
+    id: ID!
+    # Name
+    name: String
+  }
+
+  type ClientWithComment {
+    # ClientID
+    # Second comment line
+    # Third comment line
+    # Fourth comment line
+    id: ID!
+    # Name
+    name: String
+  }
+
+  type Query {
+    clients: [Client]
+    client(id: ID!): Client
+  }
+
+  type Mutation {
+    create_client(name: String!, age: Int!): Client
+    update_client(id: ID!, name: String!, age: Int!): Client
+  }
+
+  type Subscription {
+    activeClients: [Client]
+    inactiveClients: [Client]
+  }
+
+  input ClientForm {
+    name: String!
+    age: Int!
+  }
+
+  input ClientAgeForm {
+    age: Int!
+  }
+
+  enum ClientStatus {
+    NEW
+    ACTIVE
+    INACTIVE
+  }
+
+  scalar Date
+
+  scalar JSON
+`;

--- a/test/graphql/nested_types/person_entity_type.js
+++ b/test/graphql/nested_types/person_entity_type.js
@@ -1,0 +1,7 @@
+export default `
+    interface PersonEntity {
+        name: String
+        age: Int
+        dob: Date
+    }
+`;

--- a/test/graphql/nested_types/person_search_type.js
+++ b/test/graphql/nested_types/person_search_type.js
@@ -1,0 +1,7 @@
+export default `
+    union personSearch = Client | Vendor
+
+    type personQuery {
+        firstSearchResult: personSearch
+    }
+`;

--- a/test/graphql/nested_types/raw_type.graphqls
+++ b/test/graphql/nested_types/raw_type.graphqls
@@ -1,0 +1,7 @@
+type Raw {
+  field: String!
+}
+
+type Query {
+  vendors: [Raw]
+}

--- a/test/graphql/nested_types/vendor_type.js
+++ b/test/graphql/nested_types/vendor_type.js
@@ -1,0 +1,12 @@
+export default `
+  type Vendor implements PersonEntity {
+    id: ID!
+    name: String
+    age: Int
+    dob: Date
+  }
+
+  type Query {
+    vendors: [Vendor]
+  }
+`;


### PR DESCRIPTION
- Relates to #75
- Adds an `options` object as a parameter to the `fileLoader` function
- `options` object is optional and defaults to the previous, non-recursive file loader logic
- If `options.recursive` is set to true, the file loader will recursively search the given `folderPath` directory for files to load using the original logic again
- I wanted to keep the tests separated so I duplicated the original ` test/graphql/types` directory to `nested_types` and nested one of the types in a subdirectory.
  - If you prefer, I could just add a subdirectory with a new type to the original `types` directory and edit the expected response for the test