### PR TITLE
Supports already parsed documents when merging types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - FileLoader function also loads gql extension files
+- Supports already parsed documents when merging types
 
 ## [1.1.2] - 2017-08-18
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   verbose: true,
+  setupFiles: [
+    '<rootDir>/test/polyfills.js',
+  ],
 };

--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -94,7 +94,12 @@ const printDefinitions = defs => print(_makeDocumentWithDefinitions(defs));
 
 const mergeTypes = (types) => {
   const allDefs = types
-    .map(parse)
+    .map((type) => {
+      if (typeof type === 'string') {
+        return parse(type);
+      }
+      return type;
+    })
     .map(ast => ast.definitions)
     .reduce((defs, newDef) => [...defs, ...newDef], []);
 

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -1,3 +1,5 @@
+import { parse } from 'graphql';
+
 import mergeTypes from '../src/merge_types';
 import clientType from './graphql/types/client_type';
 import productType from './graphql/types/product_type';
@@ -481,6 +483,23 @@ describe('mergeTypes', () => {
 
   it('preserves the input field comments', () => {
     const types = [clientType, productType];
+    const mergedTypes = mergeTypes(types);
+    const expectedClientType = normalizeWhitespace(`
+      input ClientFormInputWithComment {
+        # Name
+        name: String!
+        # Age
+        age: Int!
+      }
+    `);
+    const separateTypes = normalizeWhitespace(mergedTypes);
+
+    expect(separateTypes).toContain(expectedClientType);
+  });
+
+  it('supports already parsed documents', () => {
+    const parsedClientType = parse(clientType);
+    const types = [parsedClientType, productType];
     const mergedTypes = mergeTypes(types);
     const expectedClientType = normalizeWhitespace(`
       input ClientFormInputWithComment {

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -1,0 +1,1 @@
+Object.values = obj => Object.keys(obj).map(key => obj[key]);


### PR DESCRIPTION
It allows for doing this:

```js
import userType from './user.graphql';

const postType = `
  type Post {
    title: String!
  }
`;

mergeTypes([
  userType,
  postType
]);

```

Reason of polyfill.js with Object.values: https://github.com/facebook/jest/issues/3687#issuecomment-304842744