### PR TITLE
chore: update deepmerge to v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1659,9 +1659,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.4.4.tgz",
-      "integrity": "sha512-k2HDUmUNygBF82hCu9RStwgIBtdckDFsrxSxqAujuAIctxR+C1z6qDrYXpjKpVy2NrpNzFGDFdZAJ6E+L3xGWw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.1.tgz",
+      "integrity": "sha512-Ndl8eeOHB9dQkmT1HWCgY3t0odl4bmWKFzjQZBYAxVTNs2B3nn5b6orimRYHKZ4FI8psvZkA1INRCW6l7vc9lQ=="
     },
     "default-require-extensions": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dist"
   ],
   "dependencies": {
-    "deepmerge": "^1.3.2"
+    "deepmerge": "^1.5.1"
   },
   "peerDependencies": {
     "graphql": "^0.10.3"


### PR DESCRIPTION
**Changes made:**
- Update `deepmerge` to `v1.5.1`

*NOTE:* deepmerge v1.5.0 fixed a bug where objects and arrays where being merged. See [here](https://github.com/KyleAMathews/deepmerge/issues/65), tests still pass without any issues due to this behavioural change in `deepmerge`.
