### PR TITLE
V1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.4] - 2017-09-15
+### Added
+- Rollup.js is now used for our build process. We now publish a `cjs` & `esm` bundle, to learn more about the changes please review the PR.[PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)
+
+### Changed
+- Updated deepmerge to v1.5.1 which fixes this deepmerge [issue](https://github.com/KyleAMathews/deepmerge/issues/65).[PR #89](https://github.com/okgrow/merge-graphql-schemas/pull/89)
+- Babel Polyfill has been removed as a dependency, we now directly bundle `object.values` & `array.includes` from `core-js` [PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)
+
 ## [1.1.3] - 2017-09-01
 ### Changed
 - FileLoader function also loads gql extension files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.1.4] - 2017-09-15
 ### Added
-- Rollup.js is now used for our build process. We now publish a `cjs` & `esm` bundle, to learn more about the changes please review the PR.[PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)
+- Rollup.js is now used for our build process. We now publish a `cjs` & `esm` bundle [PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)
 
 ### Changed
 - Updated deepmerge to v1.5.1 which fixes this deepmerge [issue](https://github.com/KyleAMathews/deepmerge/issues/65).[PR #89](https://github.com/okgrow/merge-graphql-schemas/pull/89)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Added
- Rollup.js is now used for our build process. We now publish a `cjs` & `esm` bundle. [PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)

### Changed
- Updated deepmerge to v1.5.1 which fixes this deepmerge [issue](https://github.com/KyleAMathews/deepmerge/issues/65). [PR #89](https://github.com/okgrow/merge-graphql-schemas/pull/89)
- Babel Polyfill has been removed as a dependency, we now directly bundle `object.values` & `array.includes` from `core-js` [PR #72](https://github.com/okgrow/merge-graphql-schemas/pull/72)