### PR TITLE
Add fileLoader option to allow specify file extension explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add fileLoader option to allow specify file extension explicitly.
 
 ## [1.2.0] - 2017-10-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -314,6 +314,18 @@ export default mergeResolvers(resolversArray);
 > Beware that `mergeResolvers` is simply merging plain Javascript objects together.
 This means that you should be careful with Queries, Mutations or Subscriptions with naming conflicts.
 
+You can also load files with specified extensions by setting the extensions option.  
+Only these values are supported now. `'.ts', '.js', '.gql', '.graphql', '.graphqls'`
+```js
+// ./graphql/resolvers.js
+import path from 'path';
+import { fileLoader, mergeResolvers } from 'merge-graphql-schemas';
+
+const resolversArray = fileLoader(path.join(__dirname, './resolvers'), { extensions: ['.js'] });
+
+export default mergeResolvers(resolversArray);
+```
+
 ### Server setup
 
 Here's an example using express-graphql:

--- a/src/file_loader.js
+++ b/src/file_loader.js
@@ -31,23 +31,16 @@ const fileLoader = (folderPath, options = { recursive: false }) => {
 
     if (pathObj.name.toLowerCase() === 'index') { return; }
 
-    switch (pathObj.ext) {
-      case '.ts':
-      case '.js': {
-        const file = require(f); // eslint-disable-line
-        files.push(file.default || file);
-        break;
-      }
+    const extForScript = options.extForScript ? options.extForScript : ['.ts', 'js'];
+    const extForGraphql = options.extForGraphql ? options.extForGraphql : ['.graphqls', '.gql', '.graphql'];
 
-      case '.graphqls':
-      case '.gql':
-      case '.graphql': {
-        const file = fs.readFileSync(f, 'utf8');
-        files.push(file.toString());
-        break;
-      }
-
-      default:
+    if (extForScript.findIndex(v => v === pathObj.ext) !== -1) {
+      const file = require(f); // eslint-disable-line
+      files.push(file.default || file);
+    }
+    else if (extForGraphql.findIndex((v => v === pathObj.ext) !== -1)) {
+      const file = fs.readFileSync(f, 'utf8');
+      files.push(file.toString());
     }
   });
   return files;

--- a/src/file_loader.js
+++ b/src/file_loader.js
@@ -26,19 +26,18 @@ const fileLoader = (folderPath, options = { recursive: false }) => {
                   recursiveReadDirSync(dir) :
                   readDirSync(dir);
 
+  const extForScript = options.extForScript ? options.extForScript : ['.ts', '.js'];
+  const extForGraphql = options.extForGraphql ? options.extForGraphql : ['.graphqls', '.gql', '.graphql'];
+
   schemafiles.forEach((f) => {
     const pathObj = path.parse(f);
 
     if (pathObj.name.toLowerCase() === 'index') { return; }
 
-    const extForScript = options.extForScript ? options.extForScript : ['.ts', 'js'];
-    const extForGraphql = options.extForGraphql ? options.extForGraphql : ['.graphqls', '.gql', '.graphql'];
-
-    if (extForScript.findIndex(v => v === pathObj.ext) !== -1) {
+    if (extForScript.includes(pathObj.ext)) {
       const file = require(f); // eslint-disable-line
       files.push(file.default || file);
-    }
-    else if (extForGraphql.findIndex((v => v === pathObj.ext) !== -1)) {
+    } else if (extForGraphql.includes(pathObj.ext)) {
       const file = fs.readFileSync(f, 'utf8');
       files.push(file.toString());
     }

--- a/src/file_loader.js
+++ b/src/file_loader.js
@@ -19,15 +19,16 @@ const readDirSync = dir =>
       ),
       []);
 
-const fileLoader = (folderPath, options = { recursive: false }) => {
-  const dir = folderPath;
-  const files = [];
-  const schemafiles = options.recursive === true ?
-                  recursiveReadDirSync(dir) :
-                  readDirSync(dir);
-
+const fileLoader = (folderPath, options = {}) => {
+  const recursive = options.recursive ? options.recursive : false;
   const extForScript = options.extForScript ? options.extForScript : ['.ts', '.js'];
   const extForGraphql = options.extForGraphql ? options.extForGraphql : ['.graphqls', '.gql', '.graphql'];
+
+  const dir = folderPath;
+  const files = [];
+  const schemafiles = recursive === true ?
+                  recursiveReadDirSync(dir) :
+                  readDirSync(dir);
 
   schemafiles.forEach((f) => {
     const pathObj = path.parse(f);

--- a/test/file_loader.test.js
+++ b/test/file_loader.test.js
@@ -33,12 +33,31 @@ describe('fileLoader', () => {
   });
 
   it('loads all files recursively from specified folder', () => {
-
     const types = [
       contactType, raw2Type, clientType, personEntityType, personSearchType, productType, rawType, vendorType,
     ];
 
     const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { recursive: true });
+
+    expect(loadedTypes).toEqual(types);
+  });
+
+  it('loads all files from specified folder with ext .js', () => {
+    const types = [
+      clientType, personEntityType, personSearchType, productType, vendorType,
+    ];
+
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extForScript: ['.js'], extForGraphql: [] });
+
+    expect(loadedTypes).toEqual(types);
+  });
+
+  it('loads all files from specified folder with ext .graphqls', () => {
+    const types = [
+      rawType,
+    ];
+
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extForScript: [], extForGraphql: ['.graphqls'] });
 
     expect(loadedTypes).toEqual(types);
   });

--- a/test/file_loader.test.js
+++ b/test/file_loader.test.js
@@ -47,7 +47,7 @@ describe('fileLoader', () => {
       clientType, personEntityType, personSearchType, productType, vendorType,
     ];
 
-    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extForScript: ['.js'], extForGraphql: [] });
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extensions: ['.js'] });
 
     expect(loadedTypes).toEqual(types);
   });
@@ -57,7 +57,17 @@ describe('fileLoader', () => {
       rawType,
     ];
 
-    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extForScript: [], extForGraphql: ['.graphqls'] });
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extensions: ['.graphqls'] });
+
+    expect(loadedTypes).toEqual(types);
+  });
+
+  it('unexpected extension should be ignored', () => {
+    const types = [
+      rawType,
+    ];
+
+    const loadedTypes = fileLoader(path.join(__dirname, 'graphql/types'), { extensions: ['.graphqls', '.txt'] });
 
     expect(loadedTypes).toEqual(types);
   });

--- a/test/graphql/types/should_be_ignored.txt
+++ b/test/graphql/types/should_be_ignored.txt
@@ -1,0 +1,1 @@
+This file should be ignored in fileLoader


### PR DESCRIPTION
- Added two _**optional**_ options to current option object and default to the current values.
```
extForScript: ['.ts', '.js']
extForGraphql: ['.graphqls', '.gql', '.graphql']
```
- If extForScript is set to ['.js'], then it will include *.js only.
- if extForGraphql is set to ['.graphql'], then it will include *.graphql only.
- New test cases are added.

FYI, the reason I add this PR is that, I am developing a project using Typescript and Intellij, and Intellij will auto transcpile *.ts to *.js in the same directory. So I want to include *.js only.