### PR TITLE
V1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.3.0] - 2017-10-30
 ### Added
 - Add `extensions` field to fileLoader options to allow specifying file extension explicitly. Thanks to [@Vincent-Pang](https://github.com/Vincent-Pang)[PR #99](https://github.com/okgrow/merge-graphql-schemas/pull/99)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## [1.3.0] - 2017-10-30
### Added
- Add `extensions` field to fileLoader options to allow specifying file extension explicitly. Thanks to [@Vincent-Pang](https://github.com/Vincent-Pang)[PR #99](https://github.com/okgrow/merge-graphql-schemas/pull/99)

### Fixed
- mergeResolvers now accepts single resolver array [PR #100](https://github.com/okgrow/merge-graphql-schemas/pull/100)