### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.4.0] - 2017-12-04
 ### Changed
 - Bumped  `graphql` peer dependency to version `^0.11.7`. [PR #103](https://github.com/okgrow/merge-graphql-schemas/pull/103)
 - FileLoader now accepts simple glob patterns. Thanks to [@thebergamo](https://github.com/thebergamo) [PR #106](https://github.com/okgrow/merge-graphql-schemas/pull/106)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changed
- Bumped  `graphql` peer dependency to version `^0.11.7`. [PR #103](https://github.com/okgrow/merge-graphql-schemas/pull/103)
- FileLoader now accepts simple glob patterns. Thanks to [@thebergamo](https://github.com/thebergamo) [PR #106](https://github.com/okgrow/merge-graphql-schemas/pull/106)
- bumped deepMerge to v2.0.1
- bumped npm devDependencies