### PR TITLE
V1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.5.0] - 2018-02-26
 ### Added
-- Ability to merge a GQL Type defined multiple times in seperate files. Will throw an error when fieldDefintitons have conflicting values defined. Usage `mergeTypes(types, { all: true })`. Many thanks to [@squidfunk](https://github.com/squidfunk) work in [PR #118](https://github.com/okgrow/merge-graphql-schemas/pull/118).
+- Ability to merge a GQL Type defined multiple times in separate files. Will throw an error when fieldDefintitons have conflicting values defined. Usage `mergeTypes(types, { all: true })`. Many thanks to [@squidfunk](https://github.com/squidfunk) work in [PR #118](https://github.com/okgrow/merge-graphql-schemas/pull/118).
 
 ### Changed
 - Function signature of `mergeTypes(types)` has changed to include a 2nd optional param (an options object) -> `mergeTypes(types, { all: true })`. See Added note & [PR #118](https://github.com/okgrow/merge-graphql-schemas/pull/118) for details.
 - GraphQL 0.13.x is now supported. Thanks to [@jbblanchet](https://github.com/jbblanchet) [PR #120](https://github.com/okgrow/merge-graphql-schemas/pull/120)
+- Added Node.js's `utils`,`events`, and `assert` to Rollup's external modules list.
 
 ## [1.4.0] - 2017-12-04
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,9 @@ export default [
     external: [
       'fs',
       'path',
+      'util',
+      'events',
+      'assert',
       'graphql',
       'graphql/language/visitor',
       'graphql/utilities/buildASTSchema',


### PR DESCRIPTION
**Changes Made:**
- added utils, events, assert to Rollups's external modules list.
- Bump pkg version to 1.5.0 & update changelog for v1.5.0

**Release notes:**
## [1.5.0] - 2017-02-26
### Added
- Ability to merge a GQL Type defined multiple times in separate files. Will throw an error when fieldDefintitons have conflicting values defined. Usage `mergeTypes(types, { all: true })`. Many thanks to [@squidfunk](https://github.com/squidfunk) work in [PR #118](https://github.com/okgrow/merge-graphql-schemas/pull/118).

### Changed
- Function signature of `mergeTypes(types)` has changed to include a 2nd optional param (an options object) -> `mergeTypes(types, { all: true })`. See Added note & [PR #118](https://github.com/okgrow/merge-graphql-schemas/pull/118) for details.
- GraphQL 0.13.x is now supported. Thanks to [@jbblanchet](https://github.com/jbblanchet) [PR #120](https://github.com/okgrow/merge-graphql-schemas/pull/120)
- Added Node.js's `utils`,`events`, and `assert` to Rollup's external modules list.
