### PR TITLE
Quick fix & update to handling comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated the astPrinter with the latest print.js code from graphql-js. [PR #123](https://github.com/okgrow/merge-graphql-schemas/pull/123)
+- Updated the mutation test to include some comments. [PR #123](https://github.com/okgrow/merge-graphql-schemas/pull/123)
 
 ## [1.5.0] - 2018-02-26
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -4074,7 +4074,7 @@
       "integrity": "sha512-awNp3LTrQ7dJDSX3p3PBuxNDC+WFSOrWeV6+l4Xeh2PQJVOFyQ9SZPonXRz2WZc7aIxLZsf2nDZuuuc0qyEq/A==",
       "dev": true,
       "requires": {
-        "iterall": "1.2.1"
+        "iterall": "1.2.2"
       }
     },
     "growly": {
@@ -4587,9 +4587,9 @@
       }
     },
     "iterall": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.1.tgz",
-      "integrity": "sha512-XH2awY4PboL5tG5i2P7wZ2E6oet/JkmEUpUhjcroXxBUy7bPsUOXRDMAAZe+rnH2azSXboqvyDIp5n2f7GtlCQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
       "dev": true
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepare": "npm run rollup:build",
     "lint": "eslint ./src",
     "lintfix": "eslint ./src --fix",
-    "testonly": "jest",
+    "testonly": "jest --verbose",
     "test": "npm run lint && npm run testonly",
     "test-watch": "npm run testonly -- --watch",
     "start": "npm run rollup:watch"

--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -1,9 +1,11 @@
-// Test
-import { parse } from 'graphql';
+// NOTE: Currently using a slightly modified print instead of the exported graphql version.
+import { parse /* ,print */ } from 'graphql';
 import { getDescription } from 'graphql/utilities/buildASTSchema';
+
+// TODO: Refactor code and switch to using print from graphql directly.
 import print from './utilities/astPrinter';
-import { isObjectTypeDefinition, isObjectSchemaDefinition } from './utilities/astHelpers';
 import { makeSchema, mergeableTypes } from './utilities/makeSchema';
+import { isObjectTypeDefinition, isObjectSchemaDefinition } from './utilities/astHelpers';
 
 const _isMergeableTypeDefinition = (def, all) =>
   isObjectTypeDefinition(def) && (mergeableTypes.includes(def.name.value) || all);

--- a/src/utilities/astPrinter.js
+++ b/src/utilities/astPrinter.js
@@ -1,188 +1,16 @@
-/* eslint-disable */
 /**
- *  Copyright (c) 2015, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 /**
- * ==> This file has been modified just to add comments to the printed AST
- */
+* NOTE: ==> This file has been modified just to add comments to the printed AST
+* This is a temp measure, we will move to using the original non modified printer.js ASAP.
+*/
 
 import { visit } from 'graphql/language/visitor';
-
-/**
- * Converts an AST into a string, using one set of reasonable
- * formatting rules.
- */
-export default function print(ast) {
-  return visit(ast, { leave: printDocASTReducer });
-}
-
-const printDocASTReducer = {
-  Name: node => node.value,
-  Variable: node => '$' + node.name,
-
-  // Document
-
-  Document: node => node.definitions
-    .map(node => {
-      return `${node}\n${node[0] === '#' ? '' : '\n'}`
-    })
-    .join('')
-    .trim() + '\n',
-
-  OperationDefinition(node) {
-    const op = node.operation;
-    const name = node.name;
-    const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
-    const directives = join(node.directives, ' ');
-    const selectionSet = node.selectionSet;
-    // Anonymous queries with no directives or variable definitions can use
-    // the query short form.
-    return !name && !directives && !varDefs && op === 'query' ?
-      selectionSet :
-      join([ op, join([ name, varDefs ]), directives, selectionSet ], ' ');
-  },
-
-  VariableDefinition: ({ variable, type, defaultValue }) =>
-  variable + ': ' + type + wrap(' = ', defaultValue),
-
-  SelectionSet: ({ selections }) => block(selections),
-
-  Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
-    join([
-      wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
-      join(directives, ' '),
-      selectionSet
-    ], ' '),
-
-  Argument: ({ name, value }) => name + ': ' + value,
-
-  // Fragments
-
-  FragmentSpread: ({ name, directives }) =>
-  '...' + name + wrap(' ', join(directives, ' ')),
-
-  InlineFragment: ({ typeCondition, directives, selectionSet }) =>
-    join([
-      '...',
-      wrap('on ', typeCondition),
-      join(directives, ' '),
-      selectionSet
-    ], ' '),
-
-  FragmentDefinition: ({ name, typeCondition, directives, selectionSet }) =>
-  `fragment ${name} on ${typeCondition} ` +
-  wrap('', join(directives, ' '), ' ') +
-  selectionSet,
-
-  // Value
-
-  IntValue: ({ value }) => value,
-  FloatValue: ({ value }) => value,
-  StringValue: ({ value }) => JSON.stringify(value),
-  BooleanValue: ({ value }) => JSON.stringify(value),
-  NullValue: () => 'null',
-  EnumValue: ({ value }) => value,
-  ListValue: ({ values }) => '[' + join(values, ', ') + ']',
-  ObjectValue: ({ fields }) => '{' + join(fields, ', ') + '}',
-  ObjectField: ({ name, value }) => name + ': ' + value,
-
-  // Directive
-
-  Directive: ({ name, arguments: args }) =>
-  '@' + name + wrap('(', join(args, ', '), ')'),
-
-  // Type
-
-  NamedType: ({ name }) => name,
-  ListType: ({ type }) => '[' + type + ']',
-  NonNullType: ({ type }) => type + '!',
-
-  // Type System Definitions
-
-  SchemaDefinition: ({ directives, operationTypes }) =>
-    join([
-      'schema',
-      join(directives, ' '),
-      block(operationTypes),
-    ], ' '),
-
-  OperationTypeDefinition: ({ operation, type }) =>
-  operation + ': ' + type,
-
-  ScalarTypeDefinition: ({ name, directives }) =>
-    join([ 'scalar', name, join(directives, ' ') ], ' '),
-
-  ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
-    join([
-      'type',
-      name,
-      wrap('implements ', join(interfaces, ', ')),
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
-
-  FieldDefinition: ({ name, arguments: args, type, directives }) =>
-  name +
-  wrap('(', join(args, ', '), ')') +
-  ': ' + type +
-  wrap(' ', join(directives, ' ')),
-
-  InputValueDefinition: ({ name, type, defaultValue, directives }) =>
-    join([
-      name + ': ' + type,
-      wrap('= ', defaultValue),
-      join(directives, ' ')
-    ], ' '),
-
-  InterfaceTypeDefinition: ({ name, directives, fields }) =>
-    join([
-      'interface',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
-
-  UnionTypeDefinition: ({ name, directives, types }) =>
-    join([
-      'union',
-      name,
-      join(directives, ' '),
-      '= ' + join(types, ' | ')
-    ], ' '),
-
-  EnumTypeDefinition: ({ name, directives, values }) =>
-    join([
-      'enum',
-      name,
-      join(directives, ' '),
-      block(values)
-    ], ' '),
-
-  EnumValueDefinition: ({ name, directives }) =>
-    join([ name, join(directives, ' ') ], ' '),
-
-  InputObjectTypeDefinition: ({ name, directives, fields }) =>
-    join([
-      'input',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
-
-  TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
-
-  DirectiveDefinition: ({ name, arguments: args, locations }) =>
-  'directive @' + name + wrap('(', join(args, ', '), ')') +
-  ' on ' + join(locations, ' | '),
-
-  Comment: ({ value }) => `# ${value.replace(/\n/g, '\n # ')}`,
-};
 
 /**
  * Given maybeArray, print an empty string if it is null or empty, otherwise
@@ -192,14 +20,20 @@ function join(maybeArray, separator) {
   return maybeArray ? maybeArray.filter(x => x).join(separator || '') : '';
 }
 
+function addDescription(cb) {
+  return node => join([node.description, cb(node)], '\n');
+}
+
+function indent(maybeString) {
+  return maybeString && `  ${maybeString.replace(/\n/g, '\n  ')}`;
+}
+
 /**
  * Given array, print each item on its own line, wrapped in an
  * indented "{ }" block.
  */
 function block(array) {
-  return array && array.length !== 0 ?
-    indent('{\n' + join(array, '\n')) + '\n}' :
-    '{}';
+  return array && array.length !== 0 ? `{\n${indent(join(array, '\n'))}\n}` : '';
 }
 
 /**
@@ -207,11 +41,208 @@ function block(array) {
  * print an empty string.
  */
 function wrap(start, maybeString, end) {
-  return maybeString ?
-    start + maybeString + (end || '') :
-    '';
+  return maybeString ? start + maybeString + (end || '') : '';
 }
 
-function indent(maybeString) {
-  return maybeString && maybeString.replace(/\n/g, '\n  ');
+/**
+ * Print a block string in the indented block form by adding a leading and
+ * trailing blank line. However, if a block string starts with whitespace and is
+ * a single-line, adding a leading blank line would strip that whitespace.
+ */
+function printBlockString(value, isDescription) {
+  const escaped = value.replace(/"""/g, '\\"""');
+  return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1
+    ? `"""${escaped.replace(/"$/, '"\n')}"""`
+    : `"""\n${isDescription ? escaped : indent(escaped)}\n"""`;
+}
+
+
+const printDocASTReducer = {
+  Name: node => node.value,
+  Variable: node => `$${node.name}`,
+
+  // Document
+
+  Document: node =>
+    `${node.definitions
+      .map(defNode => `${defNode}\n${defNode[0] === '#' ? '' : '\n'}`)
+      .join('')
+      .trim()}\n`,
+
+  OperationDefinition(node) {
+    const op = node.operation;
+    const name = node.name;
+    const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
+    const directives = join(node.directives, ' ');
+    const selectionSet = node.selectionSet;
+    // Anonymous queries with no directives or variable definitions can use
+    // the query short form.
+    return !name && !directives && !varDefs && op === 'query'
+      ? selectionSet
+      : join([op, join([name, varDefs]), directives, selectionSet], ' ');
+  },
+
+  VariableDefinition: ({ variable, type, defaultValue }) =>
+    `${variable}: ${type}${wrap(' = ', defaultValue)}`,
+
+  SelectionSet: ({ selections }) => block(selections),
+
+  Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
+    join(
+      [
+        wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
+        join(directives, ' '),
+        selectionSet,
+      ],
+      '  ',
+    ),
+
+  Argument: ({ name, value }) => `${name}: ${value}`,
+
+  // Fragments
+
+  FragmentSpread: ({ name, directives }) => `...${name}${wrap(' ', join(directives, ' '))}`,
+
+  InlineFragment: ({ typeCondition, directives, selectionSet }) =>
+    join(['...', wrap('on ', typeCondition), join(directives, ' '), selectionSet], ' '),
+
+  FragmentDefinition: ({ name, typeCondition, variableDefinitions, directives, selectionSet }) =>
+    // Note: fragment variable definitions are experimental and may be changed
+    // or removed in the future.
+    `${`fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
+      `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}`}${selectionSet}`,
+
+  // Value
+
+  IntValue: ({ value }) => value,
+  FloatValue: ({ value }) => value,
+  StringValue: ({ value, block: isBlockString }, key) =>
+    (isBlockString ? printBlockString(value, key === 'description') : JSON.stringify(value)),
+  BooleanValue: ({ value }) => (value ? 'true' : 'false'),
+  NullValue: () => 'null',
+  EnumValue: ({ value }) => value,
+  ListValue: ({ values }) => `[${join(values, ', ')}]`,
+  ObjectValue: ({ fields }) => `{${join(fields, ', ')}}`,
+  ObjectField: ({ name, value }) => `${name}: ${value}`,
+
+  // Directive
+
+  Directive: ({ name, arguments: args }) => `@${name}${wrap('(', join(args, ', '), ')')}`,
+
+  // Type
+
+  NamedType: ({ name }) => name,
+  ListType: ({ type }) => `[${type}]`,
+  NonNullType: ({ type }) => `${type}!`,
+
+  // Type System Definitions
+
+  SchemaDefinition: ({ directives, operationTypes }) =>
+    join(['schema', join(directives, ' '), block(operationTypes)], ' '),
+
+  OperationTypeDefinition: ({ operation, type }) => `${operation}: ${type}`,
+
+  ScalarTypeDefinition: addDescription(({ name, directives }) =>
+    join(['scalar', name, join(directives, ' ')], ' '),
+  ),
+
+  ObjectTypeDefinition: addDescription(({ name, interfaces, directives, fields }) =>
+    join(
+      [
+        'type',
+        name,
+        wrap('implements ', join(interfaces, ' & ')),
+        join(directives, ' '),
+        block(fields),
+      ],
+      ' ',
+    ),
+  ),
+
+  FieldDefinition: addDescription(
+    ({ name, arguments: args, type, directives }) =>
+      `${name + wrap('(', join(args, ', '), ')')}: ${type}${wrap(' ', join(directives, ' '))}`,
+  ),
+
+  InputValueDefinition: addDescription(({ name, type, defaultValue, directives }) =>
+    join([`${name}: ${type}`, wrap('= ', defaultValue), join(directives, ' ')], ' '),
+  ),
+
+  InterfaceTypeDefinition: addDescription(({ name, directives, fields }) =>
+    join(['interface', name, join(directives, ' '), block(fields)], ' '),
+  ),
+
+  UnionTypeDefinition: addDescription(({ name, directives, types }) =>
+    join(
+      [
+        'union',
+        name,
+        join(directives, ' '),
+        types && types.length !== 0 ? `= ${join(types, ' | ')}` : '',
+      ],
+      ' ',
+    ),
+  ),
+
+  EnumTypeDefinition: addDescription(({ name, directives, values }) =>
+    join(['enum', name, join(directives, ' '), block(values)], ' '),
+  ),
+
+  EnumValueDefinition: addDescription(({ name, directives }) =>
+    join([name, join(directives, ' ')], ' '),
+  ),
+
+  InputObjectTypeDefinition: addDescription(({ name, directives, fields }) =>
+    join(['input', name, join(directives, ' '), block(fields)], ' '),
+  ),
+
+  ScalarTypeExtension: ({ name, directives }) =>
+    join(['extend scalar', name, join(directives, ' ')], ' '),
+
+  ObjectTypeExtension: ({ name, interfaces, directives, fields }) =>
+    join(
+      [
+        'extend type',
+        name,
+        wrap('implements ', join(interfaces, ' & ')),
+        join(directives, ' '),
+        block(fields),
+      ],
+      ' ',
+    ),
+
+  InterfaceTypeExtension: ({ name, directives, fields }) =>
+    join(['extend interface', name, join(directives, ' '), block(fields)], ' '),
+
+  UnionTypeExtension: ({ name, directives, types }) =>
+    join(
+      [
+        'extend union',
+        name,
+        join(directives, ' '),
+        types && types.length !== 0 ? `= ${join(types, ' | ')}` : '',
+      ],
+      ' ',
+    ),
+
+  EnumTypeExtension: ({ name, directives, values }) =>
+    join(['extend enum', name, join(directives, ' '), block(values)], ' '),
+
+  InputObjectTypeExtension: ({ name, directives, fields }) =>
+    join(['extend input', name, join(directives, ' '), block(fields)], ' '),
+
+  DirectiveDefinition: addDescription(
+    ({ name, arguments: args, locations }) =>
+      `directive @${name}${wrap('(', join(args, ', '), ')')} on ${join(locations, ' | ')}`,
+  ),
+
+  Comment: ({ value }) => `# ${value.replace(/\n/g, '\n # ')}`,
+};
+
+/**
+ * Converts an AST into a string, using one set of reasonable
+ * formatting rules.
+ */
+export default function print(ast) {
+  return visit(ast, { leave: printDocASTReducer });
 }

--- a/test/graphql/types/client_type.js
+++ b/test/graphql/types/client_type.js
@@ -35,6 +35,7 @@ export default `
   }
 
   type Mutation {
+    # Creates a new client with their name & age
     create_client(name: String!, age: Int!): Client
     update_client(id: ID!, name: String!, age: Int!): Client
   }

--- a/test/graphql/types/product_type.js
+++ b/test/graphql/types/product_type.js
@@ -13,6 +13,7 @@ export default `
   }
 
   type Mutation {
+    # Creates a new product with it's description & price
     create_product(description: String!, price: Int!): Product
     update_product(id: ID!, description: String!, price: Int!): Product
   }

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -276,7 +276,7 @@ describe('mergeTypes', () => {
   });
 
   it('includes one schemaType on multiple merges', () => {
-    const matchSchema = /\s*schema\s+\{[^\}]+\}/gm;
+    const matchSchema = /\s*schema\s+\{[^}]+\}/gm;
     const types = mergeTypes([clientType, productType]);
     const multipleMergedTypes = mergeTypes([types, vendorType]);
     const expectedSchemaType = normalizeWhitespace(`
@@ -315,8 +315,10 @@ describe('mergeTypes', () => {
     const mergedTypes = mergeTypes(types);
     const expectedMutationType = normalizeWhitespace(`
       type Mutation {
+        # Creates a new client with their name & age
         create_client(name: String!, age: Int!): Client
         update_client(id: ID!, name: String!, age: Int!): Client
+        # Creates a new product with it's description & price
         create_product(description: String!, price: Int!): Product
         update_product(id: ID!, description: String!, price: Int!): Product
       }`);


### PR DESCRIPTION
**Changes Made:**
- Quick fix to improve comment support.
- Updated mutation test with comments

**Notes:**
- I believe we should move to using the original `print()` from `graphql-js` instead of the slightly modified `print()` function if possible.
- Will require refactoring of the `merge_types.js` code.
- Semi related to this issue [#84](https://github.com/okgrow/merge-graphql-schemas/issues/84), to resolve issue 84 I believe we should switch to using the print from graphql directly and will need to test how it handles argument comments.
