### PR TITLE
Retain directives of redeclarations of field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Correctly handle NonNullTypes when using `mergeTypes(types, { all: true})` Thanks to [PR #125](https://github.com/okgrow/merge-graphql-schemas/pull/125) by [@lastmjs](https://github.com/lastmjs)
+- Correctly merge directives when using `mergeTypes` in [PR #144](https://github.com/okgrow/merge-graphql-schemas/pull/144) by [@JulianKnodt](https://github.com/julianknodt)
 
 ## [1.5.0] - 2018-02-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -296,6 +296,27 @@ export default {
 }
 ```
 
+#### Merging Directives
+
+Directives will be stacked on top of each other, in the order of declaration.
+
+```js
+type Query {
+  client: Client @foo
+}
+type Query {
+  client: Client @bar
+}
+```
+
+Becomes
+
+```
+type Query {
+  client: Client @foo @bar
+}
+```
+
 #### Warning
 
 If you are using `graphqlHTTP` you don't need to separate the resolver into `Query/Mutation/Subscription`, otherwise it won't work. The resolvers should look like the following:

--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -69,6 +69,11 @@ const _makeMergedFieldDefinitions = (merged, candidate) => _addCommentsToAST(can
         );
       }
     }
+
+    // retain directives of both fields.
+    if (original) {
+      original.directives = original.directives.concat(field.directives);
+    }
     return fields;
   }, merged.fields);
 

--- a/test/graphql/other/query_type/directives.js
+++ b/test/graphql/other/query_type/directives.js
@@ -1,0 +1,13 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+    age: Int
+  }
+  type Query {
+    client: Client @test
+  }
+  type Query {
+    client: Client
+  }
+`;

--- a/test/graphql/other/query_type/inverse_directives.js
+++ b/test/graphql/other/query_type/inverse_directives.js
@@ -1,0 +1,13 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+    age: Int
+  }
+  type Query {
+    client: Client
+  }
+  type Query {
+    client: Client @test
+  }
+`;

--- a/test/graphql/other/query_type/stack_directives.js
+++ b/test/graphql/other/query_type/stack_directives.js
@@ -1,0 +1,13 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+    age: Int
+  }
+  type Query {
+    client: Client @foo
+  }
+  type Query {
+    client: Client @bar
+  }
+`;

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -15,6 +15,9 @@ import simpleQueryType from './graphql/other/simple_query_type';
 import disjointQueryTypes from './graphql/other/query_type/disjoint';
 import matchingQueryTypes from './graphql/other/query_type/matching';
 import conflictingQueryTypes from './graphql/other/query_type/conflicting';
+import directiveTypes from './graphql/other/query_type/directives';
+import inverseDirectiveTypes from './graphql/other/query_type/inverse_directives';
+import stackDirectiveTypes from './graphql/other/query_type/stack_directives';
 
 const normalizeWhitespace = str => str.replace(/\s+/g, ' ').trim();
 
@@ -590,6 +593,31 @@ describe('mergeTypes', () => {
         age: Int!
       }
     `);
+    const separateTypes = normalizeWhitespace(mergedTypes);
+
+    expect(separateTypes).toContain(expectedClientType);
+  });
+
+  it('Retains all directives on fields', () => {
+    const types = [directiveTypes];
+    const mergedTypes = mergeTypes(types);
+
+    const inverseTypes = [inverseDirectiveTypes];
+    const inverseMergedTypes = mergeTypes(inverseTypes);
+
+    expect(mergedTypes).toEqual(inverseMergedTypes);
+  });
+
+  it('Stacks all directives on fields', () => {
+    const types = [stackDirectiveTypes];
+    const mergedTypes = mergeTypes(types);
+
+    const expectedClientType = normalizeWhitespace(`
+      type Query {
+        client: Client @foo @bar
+      }
+      `);
+
     const separateTypes = normalizeWhitespace(mergedTypes);
 
     expect(separateTypes).toContain(expectedClientType);


### PR DESCRIPTION
In some cases, the directive of the redeclaration of a field
was being lost, and this could be fixed by swapping the order of fields.

This creates consistent behaviour, where regardless of order, all the
directives are retained. This is more predictable behaviour, because it's unclear
which directives would be retained beforehand, as it mattered the order in
which the thing was called.

TESTING: A test to verify that swapping the order of directives did not
change anything

ADDED: A simple concatenation of directive array to original in
_makeMergedFieldDefinitions. This may not be as functional as other parts of code.