### PR TITLE
Support comments for enum values

### DIFF
--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -5,7 +5,7 @@ import { getDescription } from 'graphql/utilities/buildASTSchema';
 // TODO: Refactor code and switch to using print from graphql directly.
 import print from './utilities/astPrinter';
 import { makeSchema, mergeableTypes } from './utilities/makeSchema';
-import { isObjectTypeDefinition, isObjectSchemaDefinition } from './utilities/astHelpers';
+import { isObjectTypeDefinition, isObjectSchemaDefinition, isEnumTypeDefinition } from './utilities/astHelpers';
 
 const _isMergeableTypeDefinition = (def, all) =>
   isObjectTypeDefinition(def) && (mergeableTypes.includes(def.name.value) || all);
@@ -37,10 +37,11 @@ const _makeRestDefinitions = (defs, all = false) =>
   defs
     .filter(def => _isNonMergeableTypeDefinition(def, all) && !isObjectSchemaDefinition(def))
     .map((def) => {
-      if (isObjectTypeDefinition(def)) {
+      if (isObjectTypeDefinition(def) || isEnumTypeDefinition(def)) {
         return {
           ...def,
-          fields: _addCommentsToAST(def.fields),
+          fields: def.fields ? _addCommentsToAST(def.fields) : undefined,
+          values: def.values ? _addCommentsToAST(def.values) : undefined,
         };
       }
 
@@ -90,7 +91,8 @@ const _makeMergedDefinitions = (defs, all = false) => {
             ...mergableDefs,
             [name]: {
               ...def,
-              fields: _addCommentsToAST(def.fields),
+              fields: def.fields ? _addCommentsToAST(def.fields) : undefined,
+              values: def.values ? _addCommentsToAST(def.values) : undefined,
             },
           };
         }

--- a/src/utilities/astHelpers.js
+++ b/src/utilities/astHelpers.js
@@ -8,6 +8,15 @@ const isObjectTypeDefinition = def => (
   def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
 );
 
+const isEnumTypeDefinition = def => (
+  def.kind === Kind.ENUM_TYPE_DEFINITION
+);
+
 const isObjectSchemaDefinition = def => def.kind === Kind.SCHEMA_DEFINITION;
 
-export { hasDefinitionWithName, isObjectTypeDefinition, isObjectSchemaDefinition };
+export {
+  hasDefinitionWithName,
+  isObjectTypeDefinition,
+  isObjectSchemaDefinition,
+  isEnumTypeDefinition,
+};

--- a/test/graphql/types/product_type.js
+++ b/test/graphql/types/product_type.js
@@ -23,8 +23,11 @@ export default `
   }
 
   enum ProductTypes {
+    # New
     NEW
+    # Used
     USED
+    # Refurbished
     REFURBISHED
   }
 

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -411,8 +411,11 @@ describe('mergeTypes', () => {
     const mergedTypes = mergeTypes(types);
     const expectedEnumType = normalizeWhitespace(`
       enum ProductTypes {
+        # New
         NEW
+        # Used
         USED
+        # Refurbished
         REFURBISHED
       }
     `);


### PR DESCRIPTION
To leave comments on Enum values like below. This allows us to use comments for other tools.

```
 enum ProductTypes {
    # New
     NEW
    # Used
     USED
    # Refurbished
     REFURBISHED
 }
```