### PR TITLE
fix query merge issue when combining NonNull & ListType modifiers

### DIFF
--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -55,28 +55,48 @@ const _makeMergedFieldDefinitions = (merged, candidate) => _addCommentsToAST(can
       base.name.value === field.name.value);
     if (!original) {
       fields.push(field);
-    } else if (field.type.kind === 'NamedType') {
-      if (field.type.name.value !== original.type.name.value) {
-        throw new Error(
-          `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
-          `${field.type.name.value} != ${original.type.name.value}`,
-        );
-      }
-    } else if (field.type.kind === 'NonNullType') {
-      if (field.type.type.name) {
-        if (field.type.type.name.value !== original.type.type.name.value) {
-          throw new Error(
-            `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
-            `${field.type.type.name.value} != ${original.type.type.name.value}`,
-          );
-        }
-      } else if (field.type.type.type.name) {
-        if (field.type.type.type.name.value !== original.type.type.type.name.value) {
-          throw new Error(
-            `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
-            `${field.type.type.type.name.value} != ${original.type.type.type.name.value}`,
-          );
-        }
+    } else {
+      switch (field.type.kind) {
+        case 'NamedType':
+          if (field.type.name.value !== original.type.name.value) {
+            throw new Error(
+              `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+              `${field.type.name.value} != ${original.type.name.value}`,
+            );
+          }
+          break;
+
+        case 'NonNullType':
+          if (field.type.type.name) {
+            if (field.type.type.name.value !== original.type.type.name.value) {
+              throw new Error(
+                `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+                `${field.type.type.name.value} != ${original.type.type.name.value}`,
+              );
+            }
+          } else if (field.type.type.type.name) {
+            if (field.type.type.type.name.value !== original.type.type.type.name.value) {
+              throw new Error(
+                `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+                `${field.type.type.type.name.value} != ${original.type.type.type.name.value}`,
+              );
+            }
+          }
+          break;
+
+        case 'ListType':
+          if (field.type.type.name) {
+            if (field.type.type.name.value !== original.type.type.name.value) {
+              throw new Error(
+                `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+                `${field.type.type.type.name.value} != ${original.type.type.type.name.value}`,
+              );
+            }
+          }
+          break;
+
+        default:
+          break;
       }
     }
 

--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -63,11 +63,20 @@ const _makeMergedFieldDefinitions = (merged, candidate) => _addCommentsToAST(can
         );
       }
     } else if (field.type.kind === 'NonNullType') {
-      if (field.type.type.name.value !== original.type.type.name.value) {
-        throw new Error(
-          `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
-          `${field.type.type.name.value} != ${original.type.type.name.value}`,
-        );
+      if (field.type.type.name) {
+        if (field.type.type.name.value !== original.type.type.name.value) {
+          throw new Error(
+            `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+            `${field.type.type.name.value} != ${original.type.type.name.value}`,
+          );
+        }
+      } else if (field.type.type.type.name) {
+        if (field.type.type.type.name.value !== original.type.type.type.name.value) {
+          throw new Error(
+            `Conflicting types for ${merged.name.value}.${field.name.value}: ` +
+            `${field.type.type.type.name.value} != ${original.type.type.type.name.value}`,
+          );
+        }
       }
     }
 

--- a/test/graphql/other/query_type/conflicting_non_null_list_type.js
+++ b/test/graphql/other/query_type/conflicting_non_null_list_type.js
@@ -1,0 +1,12 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+  }
+  type Query {
+    clients: [Client]
+  }
+  type Query {
+    clients: [Client]!
+  }
+`;

--- a/test/graphql/other/query_type/inverse_conflicting_non_null_list_type.js
+++ b/test/graphql/other/query_type/inverse_conflicting_non_null_list_type.js
@@ -1,0 +1,12 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+  }
+  type Query {
+    clients: [Client]!
+  }
+  type Query {
+    clients: [Client]
+  }
+`;

--- a/test/graphql/other/query_type/matching_non_null_list_type.js
+++ b/test/graphql/other/query_type/matching_non_null_list_type.js
@@ -1,0 +1,12 @@
+export default `
+  type Client {
+    id: ID!
+    name: String
+  }
+  type Query {
+    clients: [Client]!
+  }
+  type Query {
+    clients: [Client]!
+  }
+`;

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -9,7 +9,8 @@ import personSearchType from './graphql/types/person_search_type';
 import customType from './graphql/other/custom_type';
 import disjointCustomTypes from './graphql/other/custom_type/disjoint';
 import matchingCustomTypes from './graphql/other/custom_type/matching';
-import matchingQueryTypesWithNonNullListType from "./graphql/other/query_type/matching_non_null_list_type";
+import matchingNonNullListQueryTypes from "./graphql/other/query_type/matching_non_null_list_type";
+import conflictingNonNullListQueryTypes from "./graphql/other/query_type/conflicting_non_null_list_type";
 import conflictingCustomTypes from './graphql/other/custom_type/conflicting';
 
 import simpleQueryType from './graphql/other/simple_query_type';
@@ -257,7 +258,7 @@ describe('mergeTypes', () => {
     });
 
     it("merges query types with matching NonNullType-ListType definitions", () => {
-      const types = [matchingQueryTypesWithNonNullListType];
+      const types = [matchingNonNullListQueryTypes];
       const mergedTypes = mergeTypes(types);
       const expectedSchemaType = normalizeWhitespace(`
         type Query {
@@ -266,6 +267,13 @@ describe('mergeTypes', () => {
       `);
       const separateTypes = normalizeWhitespace(mergedTypes);
       expect(separateTypes).toContain(expectedSchemaType);
+    });
+
+    it("throws on conflicting NonNullType-ListType definitions", () => {
+      const types = [conflictingNonNullListQueryTypes];
+      expect(() => {
+        mergeTypes(types, { all: true });
+      }).toThrow(expect.any(Error));
     });
 
     it('throws on custom types with conflicting definitions', () => {

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -272,7 +272,7 @@ describe('mergeTypes', () => {
     it("throws on conflicting NonNullType-ListType definitions", () => {
       const types = [conflictingNonNullListQueryTypes];
       expect(() => {
-        mergeTypes(types, { all: true });
+        mergeTypes(types);
       }).toThrow(expect.any(Error));
     });
 

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -11,6 +11,7 @@ import disjointCustomTypes from './graphql/other/custom_type/disjoint';
 import matchingCustomTypes from './graphql/other/custom_type/matching';
 import matchingNonNullListQueryTypes from "./graphql/other/query_type/matching_non_null_list_type";
 import conflictingNonNullListQueryTypes from "./graphql/other/query_type/conflicting_non_null_list_type";
+import inverseConflictingNonNullListQueryTypes from "./graphql/other/query_type/inverse_conflicting_non_null_list_type";
 import conflictingCustomTypes from './graphql/other/custom_type/conflicting';
 
 import simpleQueryType from './graphql/other/simple_query_type';
@@ -273,6 +274,27 @@ describe('mergeTypes', () => {
       const types = [conflictingNonNullListQueryTypes];
       expect(() => {
         mergeTypes(types);
+      }).toThrow(expect.any(Error));
+    });
+
+    it("throws on conflicting NonNullType-ListType definitions with merge attempt", () => {
+      const types = [conflictingNonNullListQueryTypes];
+      expect(() => {
+        mergeTypes(types, { all: true });
+      }).toThrow(expect.any(Error));
+    });
+
+    it("throws on inverse conflicting NonNullType-ListType definitions", () => {
+      const types = [inverseConflictingNonNullListQueryTypes];
+      expect(() => {
+        mergeTypes(types);
+      }).toThrow(expect.any(Error));
+    });
+
+    it("throws on inverse conflicting NonNullType-ListType definitions with merge attempt", () => {
+      const types = [inverseConflictingNonNullListQueryTypes];
+      expect(() => {
+        mergeTypes(types, { all: true });
       }).toThrow(expect.any(Error));
     });
 

--- a/test/merge_types.test.js
+++ b/test/merge_types.test.js
@@ -9,6 +9,7 @@ import personSearchType from './graphql/types/person_search_type';
 import customType from './graphql/other/custom_type';
 import disjointCustomTypes from './graphql/other/custom_type/disjoint';
 import matchingCustomTypes from './graphql/other/custom_type/matching';
+import matchingQueryTypesWithNonNullListType from "./graphql/other/query_type/matching_non_null_list_type";
 import conflictingCustomTypes from './graphql/other/custom_type/conflicting';
 
 import simpleQueryType from './graphql/other/simple_query_type';
@@ -253,6 +254,18 @@ describe('mergeTypes', () => {
       `);
       const separateTypes = normalizeWhitespace(mergedTypes);
       expect(separateTypes).toContain(expectedCustomType);
+    });
+
+    it("merges query types with matching NonNullType-ListType definitions", () => {
+      const types = [matchingQueryTypesWithNonNullListType];
+      const mergedTypes = mergeTypes(types);
+      const expectedSchemaType = normalizeWhitespace(`
+        type Query {
+          clients: [Client]!
+        }
+      `);
+      const separateTypes = normalizeWhitespace(mergedTypes);
+      expect(separateTypes).toContain(expectedSchemaType);
     });
 
     it('throws on custom types with conflicting definitions', () => {


### PR DESCRIPTION
Issue found when attempting to merge a Non-Null List (i.e. combining Non-Null and List modifiers). 
This approach is documented by graphql: https://graphql.org/learn/schema/#lists-and-non-null

It looks like it wasn't accounting for `ListType` in `NonNullType` fields.
I made a fix to the code and added a test for this.

Example `field.type` in this test example `type Query { clients: [Client]! }`:
```
field.type: {
    "kind": "NonNullType",
    "type": {
        "kind": "ListType",
        "type": {
            "kind": "NamedType",
            "name": {
                "kind": "Name",
                "value": "Client",
                "loc": {
                    "start": 121,
                    "end": 127
                }
            },
            "loc": {
                "start": 121,
                "end": 127
            }
        },
        "loc": {
            "start": 120,
            "end": 128
        }
    },
    "loc": {
        "start": 120,
        "end": 129
    }
}
```