### PR TITLE
Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "typings": "typings/index.d.ts",
   "scripts": {
     "rollup:build": "cross-env BABEL_ENV=build rollup -c",
     "rollup:watch": "cross-env BABEL_ENV=build rollup -c -w",
@@ -28,7 +29,8 @@
     "schema"
   ],
   "files": [
-    "dist"
+    "dist",
+    "typings"
   ],
   "dependencies": {
     "deepmerge": "^2.1.1",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,18 @@
+import { DocumentNode, Source } from 'graphql';
+import { Dirent } from 'fs';
+
+export function mergeTypes(
+  types: Array<string | Source | DocumentNode>,
+  options?: { all: boolean }
+): string;
+
+export function mergeResolvers<T>(args: T[]): T;
+
+export function fileLoader(
+  path: string,
+  options?: {
+    recursive?: boolean;
+    extensions?: string[];
+    globOptions?: object;
+  }
+): Array<string | Buffer | Dirent>;


### PR DESCRIPTION
PR for #154.

The location of the `index.d.ts` does not matter, as long as it is referenced correctly from `package.json`.   I stuck it in `typings`, but you could just as easily stick it in `src` and use some build process to move it to (and reference it from) `dist`.
