### PR TITLE
typings; remove fs.Dirent

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,4 @@
 import { DocumentNode, Source } from 'graphql';
-import { Dirent } from 'fs';
 
 export function mergeTypes(
   types: Array<string | Source | DocumentNode>,
@@ -15,4 +14,4 @@ export function fileLoader(
     extensions?: string[];
     globOptions?: object;
   }
-): Array<string | Buffer | Dirent>;
+): Array<string | Buffer>;


### PR DESCRIPTION
fs.Dirent is only available since node 10. there might be ways to have optional imports, but that I don't know.

fixes #169