### PR TITLE
Update return type of `fileLoader` to be accepted by `mergeTypes`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,4 +14,4 @@ export function fileLoader(
     extensions?: string[];
     globOptions?: object;
   }
-): Array<string | Buffer>;
+): Array<string | any>;


### PR DESCRIPTION
Followup of #170 