### PR TITLE
chore: bump to v1.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
+## [1.5.7]
+### Fixed
+- Typescript issue introduced in previous PR. [PR #168](https://github.com/okgrow/merge-graphql-schemas/pull/172) by [@koenpunt](https://github.com/koenpunt).
+
 ## [1.5.6]
 ### Fixed
 - Support Node.js prior to v10.10, by removing the Dirent Typescript type [PR #168](https://github.com/okgrow/merge-graphql-schemas/pull/170) by [@koenpunt](https://github.com/koenpunt).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-graphql-schemas",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release v1.5.7 to Fix typescript issue introduced in previous PR.

### Fixed
- Typescript issue introduced in previous PR. [PR #168](https://github.com/okgrow/merge-graphql-schemas/pull/172) by [@koenpunt](https://github.com/koenpunt).